### PR TITLE
Disabled LTO in build script. To fix request issues.

### DIFF
--- a/kernel/build.zig
+++ b/kernel/build.zig
@@ -33,5 +33,8 @@ pub fn build(b: *std.Build) void {
     kernel.root_module.addImport("limine", limine.module("limine"));
     kernel.setLinkerScriptPath(.{ .path = "linker.ld" });
 
+    // Disable LTO. This prevents issues with limine requests
+    kernel.want_lto = false;
+
     b.installArtifact(kernel);
 }


### PR DESCRIPTION
Basiclly limine request doesnt seem to work always, idrk if this is just for limine (probably not). Anyways this options fixes it