### PR TITLE
refactor: use limine revision 2

### DIFF
--- a/kernel/src/main.zig
+++ b/kernel/src/main.zig
@@ -6,10 +6,10 @@ const std = @import("std");
 // be made volatile or equivalent. In Zig, `export var` is what we use.
 pub export var framebuffer_request: limine.FramebufferRequest = .{};
 
-// Set the base revision to 1, this is recommended as this is the latest
+// Set the base revision to 2, this is recommended as this is the latest
 // base revision described by the Limine boot protocol specification.
 // See specification for further info.
-pub export var base_revision: limine.BaseRevision = .{ .revision = 1 };
+pub export var base_revision: limine.BaseRevision = .{ .revision = 2 };
 
 inline fn done() noreturn {
     while (true) {


### PR DESCRIPTION
It seems like the revision should be 2 now. Not sure if this would break anything.

https://github.com/limine-bootloader/limine-c-template-portable/blob/5adc591b2578d092bb4e05fea544d47e61c9ada9/kernel/src/main.c#L6