### PR TITLE
Fix build error on latest zig version

### DIFF
--- a/kernel/build.zig
+++ b/kernel/build.zig
@@ -23,7 +23,7 @@ pub fn build(b: *std.Build) void {
     const limine = b.dependency("limine", .{});
     const kernel = b.addExecutable(.{
         .name = "kernel",
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
         .target = b.resolveTargetQuery(target),
         .optimize = optimize,
         .code_model = .kernel,
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
     });
 
     kernel.root_module.addImport("limine", limine.module("limine"));
-    kernel.setLinkerScriptPath(.{ .path = "linker.ld" });
+    kernel.setLinkerScriptPath(b.path("linker.ld"));
 
     // Disable LTO. This prevents issues with limine requests
     kernel.want_lto = false;


### PR DESCRIPTION
After updating zig, and running make run:
```
/home/maxim/sources/GoofyOS/kernel/build.zig:26:33: error: no field named 'path' in union 'Build.LazyPath'
        .root_source_file = .{ .path = "src/main.zig" },
```

Reproduced on clean install of template aswell. 

Seems to be due to commit ``b30ad7490891ca3522abdd0a1ffaf809df497f3d`` - 
remove deprecated LazyPath.path union tag

To fix this I simply updated the root_source_file references